### PR TITLE
Add libwebp so pillow builds with webp support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,14 @@ RUN \
     curl \
     jpeg-dev \
     libffi-dev \
+    libwebp-dev \
     py3-cffi \
     python3-dev \
     zlib-dev && \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
     jpeg \
+    libwebp-tools \
     nodejs \
     py3-pip \
     python3 \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -14,12 +14,14 @@ RUN \
     curl \
     jpeg-dev \
     libffi-dev \
+    libwebp-dev \
     py3-cffi \
     python3-dev \
     zlib-dev && \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
     jpeg \
+    libwebp-tools \
     nodejs \
     py3-pip \
     python3 \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -14,12 +14,14 @@ RUN \
     curl \
     jpeg-dev \
     libffi-dev \
+    libwebp-dev \
     py3-cffi \
     python3-dev \
     zlib-dev && \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
     jpeg \
+    libwebp-tools \
     nodejs \
     py3-pip \
     python3 \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -40,6 +40,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "25.05.21:", desc: "Add `libwebp` support." }
   - { date: "17.05.21:", desc: "Add linuxserver wheel index." }
   - { date: "23.01.21:", desc: "Rebasing to alpine 3.13." }
   - { date: "03.01.21:", desc: "Output mylar log to docker log."}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-mylar3/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Without webp, any webp comics inside of Mylar fail to load when you hit the info button. Running the following python code will return `False` because webp wasn't on the system when pillow was installed via pip.
```python
from PIL import features
print(features.check_module('webp'))
```

Inside of Mylar, you'll see a warning similar to the following:
```
WARNING    [WARNING] Unable to resize existing image: cannot identify image file <_io.BytesIO object at 0x7f2fd9bfaf40>
```

This PR adds libwebp-dev to the build phase and libwebp-tools to the runtime phase so the libcwebp libraries are available during when PIP installs Pillow (used for displaying images inside of Mylar), thus enabling webp as a Pillow feature, and so cwebp is available in the container for ComicTagger.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Allows Mylar to properly display covers for webp comics. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I modified and built the container, `docker exec -it mylar bash` > `python3` and ran 
```python
from PIL import features
print(features.check_module('webp'))
``` 
and verified that it returned true. I then loaded the front-end UI and checked that the info button would work on a comic that contained webp images.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
Worked with evilhero over on the Mylar discord to figure out this was related to Pillow being installed without the webp libraries.
